### PR TITLE
Fixed keybindings for motions in vim

### DIFF
--- a/known-shortcuts/vim.ts
+++ b/known-shortcuts/vim.ts
@@ -7,9 +7,9 @@ const app = {
     "Vim is a highly configurable text editor built to enable efficient text editing.",
   globals: {},
   shortcuts: {
-    h: "up",
+    h: "left",
     j: "down",
-    k: "left",
+    k: "up",
     l: "right",
     w: "next word",
     b: "previous word",


### PR DESCRIPTION
Fixed key bindings for vim. Previously it was that "h" means "up", and "k" means "left", when in reality it's the opposite, "h" is "left" and "k" is "up"