### PR TITLE
Update shortcuts.ts

### DIFF
--- a/helpers/shortcuts.ts
+++ b/helpers/shortcuts.ts
@@ -49,7 +49,7 @@ const tooltips: Record<string, string> = {
 };
 
 function getTooltip(key: string) {
-  return tooltips[key];
+  return ":" + tooltips[key];
 }
 function transformKeys(keys: string[]) {
   return keys.map((key: string) => {


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Cal</h3></i></summary>

This PR updates the `getTooltip` function to prepend a colon to the tooltip string returned from the `tooltips` object.



<details>
<summary><h4>Diagrams of code changes</h4></summary>

```mermaid
sequenceDiagram
    participant User
    participant getTooltip
    participant tooltips

    User->>getTooltip: Call with key
    getTooltip->>tooltips: Access tooltip for key
    tooltips-->>getTooltip: Return tooltip value
    getTooltip-->>User: Return ":" + tooltip value
```

</details>

### Key Issues
- Possible Bug: The change to prepend a colon may lead to unexpected tooltip formats if the original tooltip strings do not account for this. Ensure that all tooltips are formatted correctly after this change.

<details>
<summary><h3>Files Changed</h3></summary>

<details open>
	<summary>File: <b>/helpers/shortcuts.ts</b></summary>
	Updated the `getTooltip` function to prepend a colon to the returned tooltip string.
</details>


</details>

</details>
<!-- cal_description_end -->


